### PR TITLE
解决纹理尺寸不对的问题。

### DIFF
--- a/Qt/qmlrhi/VideoTextureItem.cpp
+++ b/Qt/qmlrhi/VideoTextureItem.cpp
@@ -158,7 +158,7 @@ QSGTexture *VideoTextureNode::texture() const
 void VideoTextureNode::sync()
 {
     m_dpr = m_window->effectiveDevicePixelRatio();
-    const QSize newSize = m_window->size() * m_dpr;
+    const QSizeF newSize = m_item->size() * m_dpr;
     bool needsNew = false;
 
     if (!texture())
@@ -166,7 +166,7 @@ void VideoTextureNode::sync()
 
     if (newSize != m_size) {
         needsNew = true;
-        m_size = newSize;
+        m_size = {qRound(newSize.width()), qRound(newSize.height())};
     }
 
     if (!needsNew)


### PR DESCRIPTION
原来的代码是把窗口的大小设置为纹理大小了，这样做是不合理的，因为用户不一定会让这个item充满整个窗口，万一用户没有让这个item填充整个窗口，纹理却还是使用整个窗口的尺寸，这样渲染的画面就不对了，所以应该获取item本身的大小。